### PR TITLE
1.2.1 hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ In addition, `value` and `show`, `encryptedValue` require two-way binding, so ad
 |`encryptedChar`|Will be placed in `:value.sync` of the original value.<br>For strings of length greater than 1, only the first character is valid.|String|'0'|
 |`activeButtonDelay`|The time when `activeButtonClass` is maintained (ms)|Number|300|
 |`pseudoClick`|Clicking a button triggers a pseudo click on another button|Boolean|false|
-|`setDefaultStyle`|'all': Use All default styles<br>'button': Use `buttonStyles`, `activeButtonStyles` default styles<br>'wrap': Use `keypadStyles`, `buttonWrapStyles` default styles<br>'none': Not use all default styles|['all', 'button', 'wrap', 'none']|'all'|
+|`defaultStyle`|'all': Use All default styles<br>'button': Use `buttonStyles`, `activeButtonStyles` default styles<br>'wrap': Use `keypadStyles`, `buttonWrapStyles` default styles<br>'none': Not use all default styles|['all', 'button', 'wrap', 'none']|'all'|
 |`stopPropagation`|Prevents the propagation of events that turn off `:show.sync`.|Boolean|true|
 
 > #### class option

--- a/src/vue-numeric-keypad.vue
+++ b/src/vue-numeric-keypad.vue
@@ -109,7 +109,7 @@ export default {
       cellWidth: 0,
       cellHeight: 0,
       defaultStyleSheet: document.createElement('style'),
-      setDefaultStyle: ['all', 'button', 'wrap', 'none'].find(s => s === this.options.setDefaultStyle) || 'all',
+      defaultStyle: ['all', 'button', 'wrap', 'none'].find(s => s === this.options.setDefaultStyle) || 'all',
       keypadStylesIndex: null,
     };
   },
@@ -176,21 +176,21 @@ export default {
         const pIdx = Math.floor((Math.random() * (l - 1)) + idx + 1) % l;
         this.activeButton(pIdx);
       }
-      let newVal = "";
+      let newVal = this.value;
       const encryptedValue = [...this.encryptedValue];
       if (this.onEncrypt) {
         if (key === -1) {
           newVal = this.value.slice(0, -1);
           encryptedValue.pop();
         } else if (key !== '') {
-          newVal = this.value + this.encryptedChar;
+          newVal += this.encryptedChar;
           encryptedValue.push(this.encryptFunc(key.toString()));
         }
       } else {
         if (key === -1) {
           newVal = this.value.slice(0, -1);
         } else {
-          newVal = this.value + key;
+          newVal += key;
         }
       }
       this.$emit("update:value", String(newVal));


### PR DESCRIPTION
1.2.1 hotfix
- Fix a bug where newVal was initialized when an blank button was clicked while using encryption
- Change `setDefaultStyle` to `defaultStyle` to give a sense of unity with other options
